### PR TITLE
initialize in background thread

### DIFF
--- a/lib/country_lookup.rb
+++ b/lib/country_lookup.rb
@@ -100,13 +100,13 @@ module CountryLookup
 
   def self.initialize
     if !@initialize_bg_thread.nil?
-      Thread.kill(@initialize_bg_thread)
+      @initialize_bg_thread.kill.join
     end
     @lookup = Lookup.new
     return nil
   end
 
-  def self.initializeAsync
+  def self.initialize_async
     if !@initialize_bg_thread.nil? && @initialize_bg_thread.alive?
       @initialize_bg_thread.kill.join
     end

--- a/lib/country_lookup.rb
+++ b/lib/country_lookup.rb
@@ -2,6 +2,9 @@ module CountryLookup
 
   class Lookup
     def initialize
+      if !@initialize_bg_thread.nil?
+        Thread.kill(@initialize_bg_thread)
+      end
       @country_codes = Array.new
       @ip_ranges = Array.new
       @country_table = Array.new
@@ -101,6 +104,14 @@ module CountryLookup
   def self.initialize
     @lookup = Lookup.new
     return nil
+  end
+
+  def self.initializeAsync
+    @initialize_bg_thread = Thread.new { self.initialize }
+  end
+
+  def self.is_ready_for_lookup
+    !@lookup.nil?
   end
 
   def self.lookup_ip_string(ip_string)

--- a/lib/country_lookup.rb
+++ b/lib/country_lookup.rb
@@ -120,14 +120,14 @@ module CountryLookup
 
   def self.lookup_ip_string(ip_string)
     if @lookup.nil?
-      @lookup = Lookup.new
+      initialize
     end
     @lookup.lookup_ip_string(ip_string)
   end
 
   def self.lookup_ip_number(ip_number)
     if @lookup.nil?
-      @lookup = Lookup.new
+      initialize
     end
     @lookup.lookup_ip_number(ip_number)
   end

--- a/lib/country_lookup.rb
+++ b/lib/country_lookup.rb
@@ -99,16 +99,17 @@ module CountryLookup
   end
 
   def self.initialize
-    if !@initialize_bg_thread.nil?
-      @initialize_bg_thread.kill.join
+    if !@initialize_bg_thread.nil? && @initialize_bg_thread.alive?
+      @initialize_bg_thread.join
+    else
+      @lookup = Lookup.new
     end
-    @lookup = Lookup.new
     return nil
   end
 
   def self.initialize_async
     if !@initialize_bg_thread.nil? && @initialize_bg_thread.alive?
-      @initialize_bg_thread.kill.join
+      return @initialize_bg_thread
     end
     @initialize_bg_thread = Thread.new { @lookup = Lookup.new }
     return @initialize_bg_thread
@@ -119,17 +120,20 @@ module CountryLookup
   end
 
   def self.lookup_ip_string(ip_string)
-    if @lookup.nil?
+    if !is_ready_for_lookup
       initialize
     end
     @lookup.lookup_ip_string(ip_string)
   end
 
   def self.lookup_ip_number(ip_number)
-    if @lookup.nil?
+    if !is_ready_for_lookup
       initialize
     end
     @lookup.lookup_ip_number(ip_number)
   end
 
+  def teardown
+    @lookup = nil
+  end
 end

--- a/lib/country_lookup.rb
+++ b/lib/country_lookup.rb
@@ -2,9 +2,6 @@ module CountryLookup
 
   class Lookup
     def initialize
-      if !@initialize_bg_thread.nil?
-        Thread.kill(@initialize_bg_thread)
-      end
       @country_codes = Array.new
       @ip_ranges = Array.new
       @country_table = Array.new
@@ -102,12 +99,19 @@ module CountryLookup
   end
 
   def self.initialize
+    if !@initialize_bg_thread.nil?
+      Thread.kill(@initialize_bg_thread)
+    end
     @lookup = Lookup.new
     return nil
   end
 
   def self.initializeAsync
-    @initialize_bg_thread = Thread.new { self.initialize }
+    if !@initialize_bg_thread.nil? && @initialize_bg_thread.alive?
+      @initialize_bg_thread.kill.join
+    end
+    @initialize_bg_thread = Thread.new { @lookup = Lookup.new }
+    return @initialize_bg_thread
   end
 
   def self.is_ready_for_lookup


### PR DESCRIPTION
Add ability to initialize in background thread. 
Also add an API to check if initialized in case you want to delay checks until then.

Ensure no race condition by killing any existing async thread.